### PR TITLE
Swift 2.0

### DIFF
--- a/CVCalendarKit/CVCalendarKitExtensions.swift
+++ b/CVCalendarKit/CVCalendarKitExtensions.swift
@@ -51,23 +51,23 @@ public enum DateFormat: String {
     case DDDDMMMMYYYY = "dddd-MMMM-yyyy"
 }
 
-private let YearUnit = NSCalendarUnit.CalendarUnitYear
-private let MonthUnit = NSCalendarUnit.CalendarUnitMonth
-private let WeekUnit = NSCalendarUnit.CalendarUnitWeekOfMonth
-private let WeekOfYearUnit = NSCalendarUnit.CalendarUnitWeekOfYear
-private let WeekdayUnit = NSCalendarUnit.CalendarUnitWeekday
-private let DayUnit = NSCalendarUnit.CalendarUnitDay
-private let HourUnit = NSCalendarUnit.CalendarUnitHour
-private let MinuteUnit = NSCalendarUnit.CalendarUnitMinute
-private let SecondUnit = NSCalendarUnit.CalendarUnitSecond
-private let AllUnits = YearUnit | MonthUnit | WeekUnit | WeekOfYearUnit | WeekdayUnit | DayUnit | HourUnit | MinuteUnit | DayUnit
+private let YearUnit = NSCalendarUnit.Year
+private let MonthUnit = NSCalendarUnit.Month
+private let WeekUnit = NSCalendarUnit.WeekOfMonth
+private let WeekOfYearUnit = NSCalendarUnit.WeekOfYear
+private let WeekdayUnit = NSCalendarUnit.Weekday
+private let DayUnit = NSCalendarUnit.Day
+private let HourUnit = NSCalendarUnit.Hour
+private let MinuteUnit = NSCalendarUnit.Minute
+private let SecondUnit = NSCalendarUnit.Second
+private let AllUnits = YearUnit.union(MonthUnit).union(WeekUnit).union(WeekOfYearUnit).union(WeekdayUnit).union(DayUnit).union(HourUnit).union(MinuteUnit).union(DayUnit)
 
 public extension NSCalendar {
     /**
     Returns the NSDateComponents instance for all main units.
     
-    :param: Date The date for components construction.
-    :returns: The NSDateComponents instance for all main units.
+    - parameter Date: The date for components construction.
+    - returns: The NSDateComponents instance for all main units.
     */
     func allComponentsFromDate(date: NSDate) -> NSDateComponents {
         return components(AllUnits, fromDate: date)
@@ -81,7 +81,7 @@ public extension NSDate {
     /**
     Calculates the date values.
     
-    :returns: A tuple with date year, month and day values.
+    - returns: A tuple with date year, month and day values.
     */
     private func dateRange() -> DateRange {
         let calendar = NSCalendar.currentCalendar()
@@ -129,7 +129,7 @@ public extension NSDate {
     /**
     Returns the first date in the current date's month.
     
-    :returns: The first date in the current date's month.
+    - returns: The first date in the current date's month.
     */
     func firstMonthDate() -> NSDate {
         return (self.day == 1)
@@ -138,7 +138,7 @@ public extension NSDate {
     /**
     Returns the last date in the current date's month.
     
-    :returns: The las date in the current date's month.
+    - returns: The las date in the current date's month.
     */
     func lastMonthDate() -> NSDate {
         return ((firstMonthDate().month + 1).day - 1)
@@ -147,7 +147,7 @@ public extension NSDate {
     /**
     Returns the first date in the current date's year.
     
-    :returns: The first date in the current date's year.
+    - returns: The first date in the current date's year.
     */
     func firstYearDate() -> NSDate {
         return ((NSDate().month == 1).day == 1)
@@ -156,7 +156,7 @@ public extension NSDate {
     /**
     Returns the last date in the current date's year.
     
-    :returns: The last date in the current date's year.
+    - returns: The last date in the current date's year.
     */
     func lastYearDate() -> NSDate {
         return (((firstYearDate().month == 12).month + 1).day - 1)
@@ -165,10 +165,10 @@ public extension NSDate {
     /**
     Returns a date description string with the given locale and format. 
     
-    :param: locale The locale for converting the date. 
-    :param: format String format for the converted date.
-    :param: style String style for the converted date.
-    :returns: A date description string with the given locale and format.
+    - parameter locale: The locale for converting the date. 
+    - parameter format: String format for the converted date.
+    - parameter style: String style for the converted date.
+    - returns: A date description string with the given locale and format.
     */
     func descriptionWithLocale(_ locale: NSLocale? = nil, format: DateFormat = .YYMMDD, style: NSDateFormatterStyle?) -> String {
         let formatter = NSDateFormatter()
@@ -190,9 +190,9 @@ public extension String {
     /**
     Returns an optional associated with date from the given string and format. 
     
-    :param: format Date format used for date conversion.
-    :param: style Date style for date conversion.
-    :returns: Either an NSDate instance or nil if a String can't be converted.
+    - parameter format: Date format used for date conversion.
+    - parameter style: Date style for date conversion.
+    - returns: Either an NSDate instance or nil if a String can't be converted.
     */
     func date(format: DateFormat, style: NSDateFormatterStyle? = .LongStyle) -> NSDate? {
         let formatter = NSDateFormatter()

--- a/CVCalendarKit/CVCalendarKitExtensions.swift
+++ b/CVCalendarKit/CVCalendarKitExtensions.swift
@@ -23,7 +23,6 @@ public enum Weekday: Int {
     func stringValue() -> String {
         switch self {
         case .Sunday: return "Sunday".localized
-        case .Sunday: return "Sunday".localized
         case .Monday: return "Monday".localized
         case .Tuesday: return "Tuesday".localized
         case .Wednesday: return "Wednesday".localized
@@ -170,7 +169,7 @@ public extension NSDate {
     - parameter style: String style for the converted date.
     - returns: A date description string with the given locale and format.
     */
-    func descriptionWithLocale(_ locale: NSLocale? = nil, format: DateFormat = .YYMMDD, style: NSDateFormatterStyle?) -> String {
+    func descriptionWithLocale(locale: NSLocale? = nil, format: DateFormat = .YYMMDD, style: NSDateFormatterStyle?) -> String {
         let formatter = NSDateFormatter()
         formatter.dateFormat = format.rawValue
         

--- a/CVCalendarKit/CVCalendarKitOperators.swift
+++ b/CVCalendarKit/CVCalendarKitOperators.swift
@@ -21,7 +21,7 @@ public enum DateUnit {
     case Day(NSDate, Int)
     
     /**
-    :returns: An associated value with a particular case.
+    - returns: An associated value with a particular case.
     */
     public func value() -> Int {
         switch self {
@@ -48,9 +48,9 @@ private typealias DateOffset = (Offset, DateOperation) -> NSDate
 /**
 Constructs a date with the offset from the source date.
 
-:param: date The given date for applying the offset.
+- parameter date: The given date for applying the offset.
 
-:returns: A function for getting the date from the offset and the assignment operation.
+- returns: A function for getting the date from the offset and the assignment operation.
 */
 private func dateWithOffset(date: NSDate) -> DateOffset {
     let comps = NSCalendar.currentCalendar().allComponentsFromDate(date)
@@ -68,8 +68,8 @@ private typealias DateOperation = (Int, Int) -> (Int)
 /**
 A bridge between construction function and the given options.
 
-:param: dateUnit A date unit providing the necessary data.
-:param: offset An offset for
+- parameter dateUnit: A date unit providing the necessary data.
+- parameter offset: An offset for
 */
 private func dateUnitOffset(dateUnit: DateUnit, offset: Int, operation: DateOperation) -> NSDate {
     let result: NSDate
@@ -93,9 +93,9 @@ private typealias ComparisonResult = (NSDate, NSDate) -> Bool
 /**
 Compares dates via return closure.
 
-:param: operation Comparison operation.
-:param: resultMerge The way of merging the results.
-:returns: A comparison function.
+- parameter operation: Comparison operation.
+- parameter resultMerge: The way of merging the results.
+- returns: A comparison function.
 */
 private func compareWithOperation(operation: ComparisonOperation, resultMerge: ResultMerge) -> ComparisonResult {
     return { dateA, dateB in
@@ -110,45 +110,45 @@ private func compareWithOperation(operation: ComparisonOperation, resultMerge: R
 // MARK: - DateUnit operators overload
 
 public func + (lhs: DateUnit, rhs: Int) -> NSDate {
-    return dateUnitOffset(lhs, rhs, { x, y in x + y })
+    return dateUnitOffset(lhs, offset: rhs, operation: { x, y in x + y })
 }
 
 public func - (lhs: DateUnit, rhs: Int) -> NSDate {
-    return dateUnitOffset(lhs, rhs, { x, y in x - y })
+    return dateUnitOffset(lhs, offset: rhs, operation: { x, y in x - y })
 }
 
 public func * (lhs: DateUnit, rhs: Int) -> NSDate {
-    return dateUnitOffset(lhs, rhs, { x, y in x * y })
+    return dateUnitOffset(lhs, offset: rhs, operation: { x, y in x * y })
 }
 
 public func / (lhs: DateUnit, rhs: Int) -> NSDate {
-    return dateUnitOffset(lhs, rhs, { x, y in x / y })
+    return dateUnitOffset(lhs, offset: rhs, operation: { x, y in x / y })
 }
 
 public func == (lhs: DateUnit, rhs: Int) -> NSDate {
-    return dateUnitOffset(lhs, rhs, { _, y in y })
+    return dateUnitOffset(lhs, offset: rhs, operation: { _, y in y })
 }
 
 // MARK: - NSDate operators overload
 
 public func == (lhs: NSDate, rhs: NSDate) -> Bool {
-    return compareWithOperation({ $0 == $1 }, { $0 && $1 && $2 })(lhs, rhs)
+    return compareWithOperation({ $0 == $1 }, resultMerge: { $0 && $1 && $2 })(lhs, rhs)
 }
 
 public func > (lhs: NSDate, rhs: NSDate) -> Bool {
-    return compareWithOperation({ $0 > $1 }, { $0 || $1 || $2 })(lhs, rhs)
+    return compareWithOperation({ $0 > $1 }, resultMerge: { $0 || $1 || $2 })(lhs, rhs)
 }
 
 public func >= (lhs: NSDate, rhs: NSDate) -> Bool {
-    return compareWithOperation({ $0 > $1 || lhs == rhs }, { $0 || $1 || $2 })(lhs, rhs)
+    return compareWithOperation({ $0 > $1 || lhs == rhs }, resultMerge: { $0 || $1 || $2 })(lhs, rhs)
 }
 
 public func < (lhs: NSDate, rhs: NSDate) -> Bool {
-    return compareWithOperation({ $0 < $1 }, { $0 || $1 || $2 })(lhs, rhs)
+    return compareWithOperation({ $0 < $1 }, resultMerge: { $0 || $1 || $2 })(lhs, rhs)
 }
 
 public func <= (lhs: NSDate, rhs: NSDate) -> Bool {
-    return compareWithOperation({ $0 < $1 || lhs == rhs }, { $0 || $1 || $2 })(lhs, rhs)
+    return compareWithOperation({ $0 < $1 || lhs == rhs }, resultMerge: { $0 || $1 || $2 })(lhs, rhs)
 }
 
 public func != (lhs: NSDate, rhs: NSDate) -> Bool {

--- a/CVCalendarKit/CVCalendarKitOperators.swift
+++ b/CVCalendarKit/CVCalendarKitOperators.swift
@@ -75,11 +75,11 @@ private func dateUnitOffset(dateUnit: DateUnit, offset: Int, operation: DateOper
     let result: NSDate
     
     switch dateUnit {
-    case .Year(let date, let value):
+    case .Year(let date, _):
         result = dateWithOffset(date)(Offset(year: offset, month: 0, day: 0), operation)
-    case .Month(let date, let value):
+    case .Month(let date, _):
         result = dateWithOffset(date)(Offset(year: 0, month: offset, day: 0), operation)
-    case .Day(let date, let value):
+    case .Day(let date, _):
         result = dateWithOffset(date)(Offset(year: 0, month: 0, day: offset), operation)
     }
     


### PR DESCRIPTION
This runs the Swift 2.0 migration tool and fixes warnings that surfaced from the new compiler. This does NOT modify the API in any way to take advantage of new language features in Swift 2.0. This simply allows the library to compile under the new Swift compiler. If I have time soon I might look into modifying the library to take full advantage of new language features.

Until this is merged if you want to support Swift 2, simply replace your previous `CVCalendarKit` entry in your Podfile with the following:

`pod 'CVCalendarKit', :git => 'https://github.com/Killectro/CVCalendarKit.git', :branch => 'swift-2.0'`

and then run `pod update`.
